### PR TITLE
Error fix for: len(line) != len(headings[group])

### DIFF
--- a/python_ags4/AGS4.py
+++ b/python_ags4/AGS4.py
@@ -142,14 +142,25 @@ def AGS4_to_dict(filepath_or_buffer, encoding='utf-8', get_line_numbers=False, r
                 # Check whether line has the same number of entries as the number of headings in the group
                 # If not, print error and exit
                 if len(temp) != len(headings[group]):
+                    # instead of raising an error and exiting, print the line number and the error along with its heading and data
+                    # then, attempt to concatenate the error line with the line below and continue after removing all line breaks in "DATA", "UNIT" and "TYPE" rows
+                    line_data = temp[0:len(temp)]
+                    error_heading = headings[group][len(line_data)-1]
+                    error_data = str(line_data).rsplit(',',1)[1]
                     rprint(f"[red]  Error: Line {i} does not have the same number of entries as the HEADING row in [bold]{group}[/bold].[/red]")
-                    raise AGS4Error(f"Line {i} does not have the same number of entries as the HEADING row in {group}.")
+                    rprint(AGS4Error(f"Line {i} does not have the same number of entries as the HEADING row in {group}."))
+                    rprint(f"{error_heading} data has a line break after: {error_data}")
+                    # use the {i} variable to get the row of data the error occured on, and pass it as an argument to a new function
+                    return concat_linebreak(line=int(i), filepath_or_buffer=filepath_or_buffer)                    
 
                 for i in range(0, len(temp)):
                     data[group][headings[group][i]].append(temp[i])
 
             else:
                 continue
+
+    except Exception as e:
+        print(e)
     finally:
         if close_file:
             f.close()
@@ -158,6 +169,31 @@ def AGS4_to_dict(filepath_or_buffer, encoding='utf-8', get_line_numbers=False, r
         return data, headings, line_numbers
 
     return data, headings
+
+def concat_linebreak(line,filepath_or_buffer,encoding='utf-8'):
+    # now {line} has been passed as an argument, open the readonly file and create a string from the row the error occured on with the row above it
+    try:
+        with open(filepath_or_buffer, "r", encoding=encoding, errors="replace") as f:
+            # get the line in the file 
+            raw_data = f.readlines()
+            fix = str(raw_data[line-1] + raw_data[line])
+            fix = str(fix.replace("\n", ""))
+            # need to append a carriage return at the end of the string, or the fixed line will append to the end of another line
+            fix = fix + "\n"
+            f.close()
+
+        with open(filepath_or_buffer, "w", encoding=encoding, errors="replace") as f:
+            raw_data.insert(line+1, fix)
+            # need to delete the two lines that have been concatenated, and insert the fixed line
+            del raw_data[line]
+            del raw_data[line-1]
+            f.writelines(raw_data)
+            f.close()
+    except Exception as e:
+        print(e)
+        pass
+    finally:
+        return AGS4_to_dict(filepath_or_buffer, encoding='utf-8', get_line_numbers=False, rename_duplicate_headers=True)
 
 
 def AGS4_to_dataframe(filepath_or_buffer, encoding='utf-8', get_line_numbers=False, rename_duplicate_headers=True):


### PR DESCRIPTION
This error appears a lot in descriptions and remarks (though it can be any text field in the AGS) when the DESC or REM contains a carriage return (line break).

When this error is raised, the AGS4_to_dataframe() function cannot be called - the solution is to open up the file in a text editor and remove the line breaks in the affected text fields.

I have not encountered this error outside of text fields containing carriage returns and its cumbersome to fix, so I've implemented a solution in place of the current function, which currently prints the error and exits.

This will concatenate the line where the error occurred with the line above it, save over the file and re-open it, proceeding in a loop until all linebreaks are removed, printing the AGS4 error, along with the heading & data for each error.